### PR TITLE
Add backend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # KCL_SW_Test_Platform
+
+This repository hosts documents and code for a web-based reporting platform. The `docs` directory contains design materials, and `backend` holds the initial Node.js REST API.
+
+See `docs/system_architecture.md` for an overview of the planned architecture.

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,24 @@
+# Backend
+
+This directory contains a minimal Express-based RESTful API, following the system architecture outlined in `../docs/system_architecture.md`.
+
+## Prerequisites
+- Node.js (v18 or later)
+- `express` package (install with `npm install`)
+
+## Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the server:
+   ```bash
+   node index.js
+   ```
+3. The API will be available on `http://localhost:3000` by default.
+
+### Example Endpoints
+- `GET /reports` – list all reports
+- `POST /reports` – create a new report
+
+This is an initial draft to bootstrap development based on the system architecture document.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const app = express();
+app.use(express.json());
+
+// Temporary in-memory storage for reports
+const reports = [];
+
+// Get all reports
+app.get('/reports', (req, res) => {
+  res.json(reports);
+});
+
+// Create a new report
+app.post('/reports', (req, res) => {
+  const report = { id: reports.length + 1, ...req.body };
+  reports.push(report);
+  res.status(201).json(report);
+});
+
+// Placeholder route for health check
+app.get('/health', (req, res) => {
+  res.send('OK');
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Minimal RESTful API based on Express",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}


### PR DESCRIPTION
## Summary
- set up `backend` folder with minimal Express server
- document API and repo root

## Testing
- `npm test` *(fails: no test specified)*
- `node index.js` *(fails: cannot find module 'express')*